### PR TITLE
fix: set Vite base path for GitHub Pages

### DIFF
--- a/rpg.toml
+++ b/rpg.toml
@@ -10,6 +10,7 @@ modules = [
     pwaEnabled = false
 
 [vite]
+    base = "/mnemonic-realms/"
     publicDir = "assets"
 
 [vite.server]


### PR DESCRIPTION
## Summary
- Set `base = "/mnemonic-realms/"` in `rpg.toml` Vite config
- Fixes 404 errors on all JS/CSS assets when deployed to GitHub Pages (which serves from `/mnemonic-realms/` subdirectory)

## Test plan
- [ ] Verify `https://arcade-cabinet.github.io/mnemonic-realms/` loads with all assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support serving the application from a subdirectory path, ensuring proper asset loading and routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->